### PR TITLE
Add devcontainer for auto-starting servers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,9 @@
   },
   "postCreateCommand": "pip install -r backend/requirements.txt && npm --prefix frontend install",
   "postStartCommand": "./.devcontainer/start.sh",
-  "forwardPorts": [3000, 5000],
+  "forwardPorts": [5173, 5000],
   "portsAttributes": {
-    "3000": {"label": "Frontend", "onAutoForward": "openBrowser", "visibility": "public"},
+    "5173": {"label": "Frontend", "onAutoForward": "openBrowser", "visibility": "public"},
     "5000": {"label": "Backend", "visibility": "public"}
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "ICTL Generator",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18"
+    }
+  },
+  "postCreateCommand": "pip install -r backend/requirements.txt && npm --prefix frontend install",
+  "postStartCommand": "./.devcontainer/start.sh",
+  "forwardPorts": [3000, 5000],
+  "portsAttributes": {
+    "3000": {"label": "Frontend", "onAutoForward": "openBrowser", "visibility": "public"},
+    "5000": {"label": "Backend", "visibility": "public"}
+  }
+}

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# Start backend
+(cd backend && nohup python app.py >/workspace/backend.log 2>&1 &)
+
+# Start frontend
+(cd frontend && nohup npm run dev >/workspace/frontend.log 2>&1 &)
+

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ npm install
 npm run dev
 ```
 
-4. Make ports 3000 (frontend) and 5000 (backend) public.
+4. Make ports 5173 (frontend) and 5000 (backend) public.
+
+If you're using GitHub Codespaces, the included `.devcontainer` configuration
+automatically installs dependencies, starts both servers, and forwards these
+ports for you.
 
 ---
 


### PR DESCRIPTION
## Summary
- add devcontainer config to install dependencies automatically and start backend & frontend
- set ports 3000 and 5000 to be public in Codespaces

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684225057dd8832b97a49329d50fa1e3